### PR TITLE
GovernanceManager tests and MembershipManager optimizations

### DIFF
--- a/hardhat/contracts/contractUpgradeTests/GovernanceManagerV2.sol
+++ b/hardhat/contracts/contractUpgradeTests/GovernanceManagerV2.sol
@@ -9,12 +9,7 @@ import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
-/**
- * @title GovernanceManager
- * @dev Manages governance-related functions and access control.
- */
-
-contract GovernanceManager is Initializable, UUPSUpgradeable, OwnableUpgradeable {
+contract GovernanceManagerV2 is Initializable, UUPSUpgradeable, OwnableUpgradeable {
 
 // ====================================================================================================================
 //                                                  CUSTOM ERRORS
@@ -281,12 +276,5 @@ contract GovernanceManager is Initializable, UUPSUpgradeable, OwnableUpgradeable
         return relayer;
     }
 
-    /**
-     * @notice Gets the address of the membership manager.
-     * @return address of the membership manager.
-     */
-    function getMembershipManager() external view onlyOwner returns (address) {
-        return membershipManager;
-    }
 
 }

--- a/hardhat/contracts/contractUpgradeTests/MembershipManagerV2.sol
+++ b/hardhat/contracts/contractUpgradeTests/MembershipManagerV2.sol
@@ -17,7 +17,7 @@ import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/O
 import { Clones } from "@openzeppelin/contracts/proxy/Clones.sol";
 
 /**
- * @title MembershipManager
+ * @title MembershipManagerV2
  * @dev A contract to manage membership in groups using Merkle trees and zk-SNARKs.
  * It allows for initializing and updating Merkle roots, verifying proofs, managing group NFTs,
  * and adding/removing members. This contract acts as a factory for ERC721IgnitionZK NFT contracts.
@@ -25,7 +25,7 @@ import { Clones } from "@openzeppelin/contracts/proxy/Clones.sol";
  * zk-SNARK verifier for privacy-preserving proof verification and dedicated ERC721 NFTs for membership tokens.
  * It is designed to be upgradeable via the UUPS proxy pattern by the governor.
  */
-contract MembershipManager is Initializable, UUPSUpgradeable, OwnableUpgradeable {
+contract MembershipManagerV2 is Initializable, UUPSUpgradeable, OwnableUpgradeable {
 
 // ====================================================================================================================
 //                                                  CUSTOM ERRORS
@@ -444,15 +444,6 @@ contract MembershipManager is Initializable, UUPSUpgradeable, OwnableUpgradeable
      */
     function getNftImplementation() external view onlyOwner returns (address) {
         return nftImplementation;
-    }
-
-    /**
-     * @notice Retrieves the maximum number of members that can be added in a single batch transaction.
-     * @dev Only callable by the owner (governor).
-     * @return The maximum batch size for member additions.
-     */
-    function getMaxMembersBatch() external view onlyOwner returns (uint256) {
-        return MAX_MEMBERS_BATCH;
     }
 
 // ====================================================================================================================

--- a/hardhat/contracts/governance/GovernanceManager.sol
+++ b/hardhat/contracts/governance/GovernanceManager.sol
@@ -198,6 +198,44 @@ contract GovernanceManager is Initializable, UUPSUpgradeable, OwnableUpgradeable
         IMembershipManager(membershipManager).burnMemberNft(memberAddress, groupKey);
     }
 
+    /**
+     * @notice Delegates the revokeMinterRole call to the membership manager.
+     * @dev Only callable by the relayer.
+     * @param nftClone The address of the NFT clone contract.
+     */
+    function delegateRevokeMinterRole(address nftClone) external onlyRelayer {
+        IMembershipManager(membershipManager).revokeMinterRole(nftClone);
+    }
+
+    /**
+     * @notice Delegates the revokeBurnerRole call to the membership manager.
+     * @dev Only callable by the relayer.
+     * @param nftClone The address of the NFT clone contract.
+     */
+    function delegateRevokeBurnerRole(address nftClone) external onlyRelayer {
+        IMembershipManager(membershipManager).revokeBurnerRole(nftClone);
+    }
+
+    /**
+     * @notice Delegates the grantMinterRole call to the membership manager.
+     * @dev Only callable by the relayer.
+     * @param nftClone The address of the NFT clone contract.
+     * @param grantTo The address to grant the minter role to.
+     */
+    function delegateGrantMinterRole(address nftClone, address grantTo) external onlyRelayer {
+        IMembershipManager(membershipManager).grantMinterRole(nftClone, grantTo);
+    }
+
+    /**
+     * @notice Delegates the grantBurnerRole call to the membership manager.
+     * @dev Only callable by the relayer.
+     * @param nftClone The address of the NFT clone contract.
+     * @param grantTo The address to grant the burner role to.
+     */
+    function delegateGrantBurnerRole(address nftClone, address grantTo) external onlyRelayer {
+        IMembershipManager(membershipManager).grantBurnerRole(nftClone, grantTo);
+    }
+
 // ====================================================================================================================
 //                           EXTERNAL VIEW FUNCTIONS (FORWARDED VIA GOVERNANCE)
 // ====================================================================================================================

--- a/hardhat/contracts/interfaces/IMembershipManager.sol
+++ b/hardhat/contracts/interfaces/IMembershipManager.sol
@@ -40,7 +40,7 @@ interface IMembershipManager {
     function verifyProof(uint256[24] calldata proof, uint256[3] calldata publicSignals, bytes32 groupKey) external;
     function deployGroupNft(bytes32 groupKey, string calldata name, string calldata symbol) external returns (address);
     function getGroupNftAddress(bytes32 groupKey) external view returns (address);
-    function getNullifier(bytes32 groupKey, bytes32 nullifier) external view returns (bool);
+    function getNullifierStatus(bytes32 groupKey, bytes32 nullifier) external view returns (bool);
     function getVerifier() external view returns (address);
     function getGovernor() external view returns (address);
     function getNftImplementation() external view returns (address);
@@ -48,4 +48,8 @@ interface IMembershipManager {
     function mintNftToMember(address memberAddress, bytes32 groupKey) external;
     function mintNftToMembers(address[] calldata memberAddresses, bytes32 groupKey) external;
     function burnMemberNft(address memberAddress, bytes32 groupKey) external;
+    function revokeMinterRole(address nftClone) external;
+    function revokeBurnerRole(address nftClone) external;
+    function grantMinterRole(address nftClone, address grantTo) external;
+    function grantBurnerRole(address nftClone, address grantTo) external;
 }

--- a/hardhat/contracts/managers/MembershipManager.sol
+++ b/hardhat/contracts/managers/MembershipManager.sol
@@ -104,6 +104,20 @@ contract MembershipManager is Initializable, UUPSUpgradeable, OwnableUpgradeable
      * @param tokenId The ID of the burned membership token.
      */
     event MemberNftBurned(bytes32 indexed groupKey, address indexed memberAddress, uint256 tokenId);
+    /**
+     * @notice Emitted when a role is revoked from the NFT clone.
+     * @param nftClone The address of the NFT contract clone from which the role was revoked.
+     * @param role The role that was revoked (e.g., MINTER_ROLE, BURNER_ROLE).
+     * @param revokedFrom The address from which the role was revoked (usually this contract).
+     */
+    event RoleRevoked(address indexed nftClone, bytes32 role, address indexed revokedFrom);
+    /**
+     * @notice Emitted when a role is granted to an address in the NFT clone.
+     * @param nftClone The address of the NFT contract clone to which the role was granted.
+     * @param role The role that was granted (e.g., MINTER_ROLE, BURNER_ROLE).
+     * @param grantedTo The address to which the role was granted.
+     */
+    event RoleGranted(address indexed nftClone, bytes32 role, address indexed grantedTo);
 
 // ====================================================================================================================
 //                                          STATE VARIABLES
@@ -459,7 +473,6 @@ contract MembershipManager is Initializable, UUPSUpgradeable, OwnableUpgradeable
 //                                       EXTERNAL HELPER FUNCTIONS
 // ====================================================================================================================
 
-
     /** 
      * @notice Revokes the MINTER_ROLE from the specified NFT clone.
      * @param nftClone The address of the NFT contract clone from which to revoke the role.
@@ -506,6 +519,8 @@ contract MembershipManager is Initializable, UUPSUpgradeable, OwnableUpgradeable
     function _revokeRole(address nftClone, bytes32 role) private {
         IERC721IgnitionZK nft = IERC721IgnitionZK(nftClone);
         nft.revokeRole(role, address(this));
+
+        emit RoleRevoked(nftClone, role, address(this));
     }
 
     /**
@@ -517,6 +532,8 @@ contract MembershipManager is Initializable, UUPSUpgradeable, OwnableUpgradeable
     function _grantRole(address nftClone, bytes32 role, address grantTo) private {
         IERC721IgnitionZK nft = IERC721IgnitionZK(nftClone);
         nft.grantRole(role, grantTo);
+
+        emit RoleGranted(nftClone, role, grantTo);
     }
 
     /**

--- a/hardhat/contracts/token/ERC721IgnitionZK.sol
+++ b/hardhat/contracts/token/ERC721IgnitionZK.sol
@@ -46,23 +46,6 @@ contract ERC721IgnitionZK is Initializable, ContextUpgradeable, ERC721Upgradeabl
         _grantRole(BURNER_ROLE, initialBurner);
         _grantRole(BURNER_ROLE, initialAdmin);
     }
-    /*
-    constructor(
-        address initialAdmin, 
-        address initialMinter,
-        address initialBurner,
-        string memory name_, 
-        string memory symbol_
-        ) ERC721(name_, symbol_) {
-            _grantRole(DEFAULT_ADMIN_ROLE, initialAdmin);
-
-            _grantRole(MINTER_ROLE, initialMinter);
-            _grantRole(MINTER_ROLE, initialAdmin); // Admin can also mint
-            
-            _grantRole(BURNER_ROLE, initialBurner);
-            _grantRole(BURNER_ROLE, initialAdmin); // Admin can also burn
-    }
-    */
 
     function safeMint(address to) external onlyRole(MINTER_ROLE) returns (uint256) {
         uint256 tokenId = _nextTokenId++;

--- a/hardhat/contracts/token/ERC721IgnitionZK.sol
+++ b/hardhat/contracts/token/ERC721IgnitionZK.sol
@@ -8,6 +8,7 @@ import {ERC721EnumerableUpgradeable} from "@openzeppelin/contracts-upgradeable/t
 import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {ContextUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 /**
 * @title ERC721IgnitionZK
@@ -16,6 +17,10 @@ import {ContextUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/Cont
 * It is owned by a governor who can manage the membership tokens.
 */
 contract ERC721IgnitionZK is Initializable, ContextUpgradeable, ERC721Upgradeable, ERC721EnumerableUpgradeable, ERC721BurnableUpgradeable, AccessControlUpgradeable {
+    
+    // Custom error for non-transferability
+    error TransferNotAllowed();
+
     uint256 private _nextTokenId;
 
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
@@ -60,6 +65,23 @@ contract ERC721IgnitionZK is Initializable, ContextUpgradeable, ERC721Upgradeabl
         _burn(tokenId);
     }
 
+    // --- BLOCK APPROVALS -------------------------------------------------
+    function approve(address to, uint256 tokenId)
+        public
+        pure
+        override(IERC721, ERC721Upgradeable)
+    {
+        revert TransferNotAllowed();
+    }
+
+    function setApprovalForAll(address operator, bool approved)
+        public
+        pure
+        override(IERC721, ERC721Upgradeable)
+    {
+        revert TransferNotAllowed();
+    }
+
     // The following functions are overrides required by Solidity.
 
     function _update(address to, uint256 tokenId, address auth)
@@ -67,6 +89,13 @@ contract ERC721IgnitionZK is Initializable, ContextUpgradeable, ERC721Upgradeabl
         override(ERC721Upgradeable, ERC721EnumerableUpgradeable)
         returns (address)
     {
+        // --- BLOCK TRANSFERS -------------------------------------------------
+        address from = _ownerOf(tokenId);
+
+        // allow mint  (from == 0)  and burn  (to == 0)
+        if (from != address(0) && to != address(0)) {
+            revert TransferNotAllowed();
+        }
         return super._update(to, tokenId, auth);
     }
 

--- a/hardhat/hardhat.config.js
+++ b/hardhat/hardhat.config.js
@@ -23,8 +23,9 @@ module.exports = {
       "MembershipManager",
       "ERC721IgnitionZK",
       "MembershipVerifier",
-      "Governor",
+      "GovernanceManager"
     ],
+    except: ["MembershipManagerV2", "GovernanceManagerV2"],
   },
   networks: {
     sepolia: {

--- a/hardhat/package.json
+++ b/hardhat/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hardhat",
+  "name": "ignitionzkhardhat",
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {

--- a/hardhat/test/GovernanceManager.test.js
+++ b/hardhat/test/GovernanceManager.test.js
@@ -407,6 +407,72 @@ describe("GovernanceManager", function () {
             );
     });
 
+    it("delegateRevokeMinterRole: should allow the relayer to revoke the minter role from the membership manager and emit event", async function () {
+        await governanceManager.connect(relayer).delegateDeployGroupNft(groupKey, nftName, nftSymbol);
+        const nftAddress = await governanceManager.connect(relayer).delegateGetGroupNftAddress(groupKey);
+        const role = await nftImplementation.attach(nftAddress).MINTER_ROLE();
+        await expect(governanceManager.connect(relayer).delegateRevokeMinterRole(nftAddress))
+            .to.emit(
+                membershipManager,
+                "RoleRevoked"
+            )
+            .withArgs(nftAddress, role, membershipManager.target);
+    });
+
+    it("delegateRevokeMinterRole: should not allow a non-relayer to revoke the minter role", async function () {
+        await governanceManager.connect(relayer).delegateDeployGroupNft(groupKey, nftName, nftSymbol);
+        const nftAddress = await governanceManager.connect(relayer).delegateGetGroupNftAddress(groupKey);
+        await expect(governanceManager.connect(deployer).delegateRevokeMinterRole(nftAddress))
+            .to.be.revertedWithCustomError(
+                governanceManager, 
+                "OnlyRelayerAllowed"
+            );
+    });
+
+    it("delegateGrantMinterRole: should allow the relayer to grant the minter role to a user and emit event", async function () {
+        await governanceManager.connect(relayer).delegateDeployGroupNft(groupKey, nftName, nftSymbol);
+        const nftAddress = await governanceManager.connect(relayer).delegateGetGroupNftAddress(groupKey);
+        const role = await nftImplementation.attach(nftAddress).MINTER_ROLE();
+        await expect(governanceManager.connect(relayer).delegateGrantMinterRole(nftAddress, user1Address))
+            .to.emit(
+                membershipManager,
+                "RoleGranted"
+            )
+            .withArgs(nftAddress, role, user1Address);
+    });
+
+    it("delegateGrantMinterRole: should not allow a non-relayer to grant the minter role", async function () {
+        await governanceManager.connect(relayer).delegateDeployGroupNft(groupKey, nftName, nftSymbol);
+        const nftAddress = await governanceManager.connect(relayer).delegateGetGroupNftAddress(groupKey);
+        await expect(governanceManager.connect(deployer).delegateGrantMinterRole(nftAddress, user1Address))
+            .to.be.revertedWithCustomError(
+                governanceManager, 
+                "OnlyRelayerAllowed"
+            );
+    });
+
+    it("delegateRevokeBurnerRole: should allow the relayer to revoke the burner role from the membership manager and emit event", async function () {
+        await governanceManager.connect(relayer).delegateDeployGroupNft(groupKey, nftName, nftSymbol);
+        const nftAddress = await governanceManager.connect(relayer).delegateGetGroupNftAddress(groupKey);
+        const role = await nftImplementation.attach(nftAddress).BURNER_ROLE();
+        await expect(governanceManager.connect(relayer).delegateRevokeBurnerRole(nftAddress))
+            .to.emit(
+                membershipManager,
+                "RoleRevoked"
+            )
+            .withArgs(nftAddress, role, membershipManager.target);
+    });
+
+    it("delegateRevokeBurnerRole: should not allow a non-relayer to revoke the burner role", async function () {
+        await governanceManager.connect(relayer).delegateDeployGroupNft(groupKey, nftName, nftSymbol);
+        const nftAddress = await governanceManager.connect(relayer).delegateGetGroupNftAddress(groupKey);
+        await expect(governanceManager.connect(deployer).delegateRevokeBurnerRole(nftAddress))
+            .to.be.revertedWithCustomError(
+                governanceManager, 
+                "OnlyRelayerAllowed"
+            ); 
+    });
+
     it("delegateGetVerifier: should allow the relayer to view the address of the membership verifier", async function () {
         const verifierAddress = await governanceManager.connect(relayer).delegateGetVerifier();
         expect(verifierAddress).to.equal(membershipVerifier.target);
@@ -526,4 +592,6 @@ describe("GovernanceManager", function () {
                 "OwnableUnauthorizedAccount"
             );
     });
+
+
 });

--- a/zk/utils/copyToPublicFolder.sh
+++ b/zk/utils/copyToPublicFolder.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Copy necessary files to the public folder
+cp -f circuits/${CIRCUIT_PATH}/build/${CIRCUIT_FILENAME}_js/${CIRCUIT_FILENAME}.wasm \
+      ../frontend/public/${CIRCUIT_FILENAME}
+
+cp -f circuits/${CIRCUIT_PATH}/build/${CIRCUIT_FILENAME}_final.zkey \
+      ../frontend/public/${CIRCUIT_FILENAME}
+
+cp -f circuits/${CIRCUIT_PATH}/build/${CIRCUIT_FILENAME}_key.json \
+      ../frontend/public/${CIRCUIT_FILENAME}

--- a/zk/utils/runZkSnarkWorkflow_1to4.sh
+++ b/zk/utils/runZkSnarkWorkflow_1to4.sh
@@ -12,3 +12,8 @@ export PTAU_POWER=14
 ./utils/3_generateKeys.sh
 
 ./utils/4_exportVerifierContract.sh
+
+# copy necessary files to the public folder
+echo "Copying necessary files to the public folder..."
+./utils/copyToPublicFolder.sh
+echo "Files copied successfully."


### PR DESCRIPTION
* added tests to GovernanceManager and MembershipManager
* removed governor state variable from MembershipManager
* changed default admin role of the NFT clones
* added helper functions for granting and revoking minter and burner roles
* organised contracts by grouping relevant functions together
* added a script that automatically copies the circuit files over to the public folder after compilation