### PR TITLE
Phase2/anastasia vote circuit

### DIFF
--- a/hardhat/contracts/interfaces/IVoteManager.sol
+++ b/hardhat/contracts/interfaces/IVoteManager.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+interface IVoteManager {
+
+    // Enums
+    enum VoteChoice { Yes, No, Abstain }
+
+    /**
+     * @notice Sets the address of the vote verifier contract.
+     * @param _voteVerifier The address of the new vote verifier contract.
+     */
+    function setVoteVerifier(address _voteVerifier) external;
+
+    /**
+     * @notice Verifies a zk-SNARK proof for a vote.
+     * @param proof The zk-SNARK proof to verify.
+     * @param publicSignals The public signals associated with the proof.
+     * @param contextKey The pre-computed context hash (group, epoch).
+     * @param groupKey The unique identifier for the voting group.
+     * @param currentRoot The current Merkle root from the MembershipManager contract.
+     * @param choice The vote choice (Yes, No, Abstain).
+     */
+    function verifyVote(
+        uint256[24] calldata proof,
+        uint256[4] calldata publicSignals,
+        bytes32 contextKey,
+        bytes32 groupKey,
+        bytes32 currentRoot,
+        VoteChoice choice
+    ) external;
+
+    /**
+     * @notice Sets the member count for a voting group.
+     * @param groupKey The unique identifier for the voting group.
+     * @param _memberCount The number of members in the voting group.
+     */
+    function setMemberCount(bytes32 groupKey, uint256 _memberCount) external;
+   
+}

--- a/hardhat/contracts/interfaces/IVoteVerifier.sol
+++ b/hardhat/contracts/interfaces/IVoteVerifier.sol
@@ -7,6 +7,6 @@ interface IVoteVerifier {
     function verifyProof(
         uint256[24] calldata _proof, 
         uint256[4] calldata _pubSignals
-    ) public view returns (bool);
+    ) external view returns (bool);
 
 }

--- a/hardhat/contracts/managers/VoteManager.sol
+++ b/hardhat/contracts/managers/VoteManager.sol
@@ -8,53 +8,193 @@ import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/I
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { ERC165Upgradeable } from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 
+// Interfaces:
 import { IVoteVerifier } from "../interfaces/IVoteVerifier.sol";
-
+import { IVoteManager } from "../interfaces/IVoteManager.sol";
 
 contract VoteManager is Initializable, OwnableUpgradeable, UUPSUpgradeable, IVoteManager, ERC165Upgradeable {
 
+// ====================================================================================================================
+//                                                  CUSTOM ERRORS
+// ====================================================================================================================
+    
+    // ====================================================================================================
+    // MERKLE ROOT ERRORS
+    // ====================================================================================================
+
+    /// @notice Thrown if the provided Merkle root does not match the expected root.
     error InvalidMerkleRoot();
-    error InvalidContextHash();
-    error VoteNullifierAlreadyUsed();
+
+    /// @notice Thrown if a Merkle root has not been initialized for a group.
     error RootNotYetInitialized();
+
+    // ====================================================================================================
+    // PROOF ERRORS
+    // ====================================================================================================
+    
+    /// @notice Thrown if the context hash does not match the expected value.
+    error InvalidContextHash();
+
+    /// @notice Thrown if the vote nullifier has already been used.
+    error VoteNullifierAlreadyUsed();
+    
+    /// @notice Thrown if the provided proof is invalid.
+    /// @param contextKey The context key associated with the vote.
+    /// @param proofVoteNullifier The nullifier associated with the vote proof.
     error InvalidVoteProof(bytes32 contextKey, bytes32 proofVoteNullifier);
+
+    // ====================================================================================================
+    // GROUP PARAM ERRORS (memberCount, Quorum)
+    // ====================================================================================================
+    
+    /// @notice Thrown if the member count is zero or greater than 1024.
     error InvalidMemberCount();
+
+    /// @notice Thrown if the quorum is less than 25.
     error QuorumCannotBeLowerThan25();
+
+    /// @notice Thrown if the group parameters (member count or quorum) are zero.
     error GroupParamsCannotBeZero();
 
+    /// @notice Thrown if the x1 and x2 inputs for linear interpolation are invalid.
+    error InvalidX1X2Inputs();
+
+    /// @notice Thrown if the y1 and y2 inputs for linear interpolation are invalid.
+    error InvalidY1Y2Inputs();
+
+    /// @notice Thrown if the x input for linear interpolation is invalid.
+    error InvalidXInput();
+
+    // ====================================================================================================
+    // GENERAL ERRORS
+    // ====================================================================================================
+
+    /// @notice Thrown if the provided address is not a contract.
+    error AddressIsNotAContract();
+
+    /// @notice Thrown if the provided address does not support the IVoteVerifier interface.
+    error AddressDoesNotSupportInterface();
+
+    /// @notice Thrown if the provided address is zero.
+    error AddressCannotBeZero();
+
+    /// @notice Thrown if the provided key is zero.
+    error KeyCannotBeZero();
+
+// ====================================================================================================================
+//                                                  EVENTS
+// ====================================================================================================================
+
+    /**
+     * @notice Emitted when a vote verifier address is set.
+     * @param voteVerifier The address of the vote verifier contract.
+     */
     event VoteVerifierAddressSet(address indexed voteVerifier);
-    event VoteVerified(bytes32 indexed contextKey, indexed proofVoteNullifier, proofVoteContentHash);
+
+    /**
+     * @notice Emitted when a vote is verified.
+     * @param contextKey The context key associated with the vote.
+     * @param voteNullifier The nullifier associated with the vote proof.
+     * @param voteContentHash The content hash of the vote.
+     */
+    event VoteVerified(bytes32 indexed contextKey, bytes32 indexed voteNullifier, bytes32 voteContentHash);
+
+    /**
+     * @notice Emitted when a quorum is set for a group.
+     * @param groupKey The unique identifier for the group.
+     * @param quorum The quorum percentage set for the group.
+     */
     event QuorumSet(bytes32 indexed groupKey, uint256 indexed quorum);
+
+    /**
+     * @notice Emitted when a member count is set for a group.
+     * @param groupKey The unique identifier for the group.
+     * @param memberCount The number of members in the group.
+     */
     event MemberCountSet(bytes32 indexed groupKey, uint256 memberCount);
 
-    enum VoteChoice { Abstain, Yes, No }
+    /**
+     * @notice Emitted when a vote tally is updated.
+     * @param contextKey The context key associated with the vote.
+     * @param abstain The number of abstain votes.
+     * @param yes The number of yes votes.
+     * @param no The number of no votes.
+     */
+    event VoteTallyUpdated(bytes32 contextKey, uint256 abstain, uint256 yes, uint256 no);
 
+    /**
+     * @notice Emitted when a proposal's status is updated.
+     * @param contextKey The context key associated with the proposal.
+     * @param passed Indicates whether the proposal has passed (true) or not (false).
+     */
+    event ProposalStatusUpdated(bytes32 contextKey, bool passed);
+
+// ====================================================================================================================
+//                                          STATE VARIABLES
+// NOTE: Once the contract is deployed do not change the order of the variables. If this contract is updated append new variables to the end of this list. 
+// ====================================================================================================================
+
+    // ====================================================================================================
+    // STRUCTS & ENUMS
+    // ====================================================================================================
+    
+    /// @dev The choices available for voting.
+    //enum VoteChoice { Abstain, Yes, No } -- defined in IVoteManager
+
+    /// @dev The vote tally struct, which contains the counts of abstain, yes, and no votes.
     struct VoteTally {
         uint256 abstain;
         uint256 yes;
         uint256 no;
     }
 
+    /// @dev The proposal status struct, which contains the vote tally and a boolean indicating if the proposal has passed.
+    /// Passed status is determined by the quorum and majority of votes.
     struct ProposalResult {
         VoteTally tally;
         bool passed;
     }
-
-    mapping(bytes32 => ProposalResult) private proposalResults; // voteContextHash (group, epoch, proposal) => VoteTally
-    mapping(bytes32 => bool) private voteNullifiers; // status of vote nullifier => used (true, false) 
-
+    
+    /// @dev The GroupParams struct, which contains the member count and quorum percentage for a group.
     struct GroupParams {
         uint256 memberCount;
         uint256 quorum;
     }
 
-    mapping(bytes32 => GroupParams) private groupParams; // groupKey => GroupGovernance
+    // ====================================================================================================
+    // MAPPINGS
+    // ====================================================================================================
 
+    /// @dev The mapping of context keys to proposal results (vote tally and passed status). Key: contextKey (bytes32) => ProposalResult 
+    mapping(bytes32 => ProposalResult) private proposalResults; 
+
+    /// @dev The mapping of vote nullifiers. Key: voteNullifier (bytes32) => (bool) true if the vote nullifier has been used
+    mapping(bytes32 => bool) private voteNullifiers;  
+
+    /// @dev The mapping of group governance parameters. Key: groupKey (bytes32) => GroupParams
+    mapping(bytes32 => GroupParams) private groupParams; // groupKey => GroupParams
+
+    // ====================================================================================================
+    // ADDRESSES
+    // ====================================================================================================
+
+    /// @dev The interface of the vote verifier contract.
     IVoteVerifier private voteVerifier;
 
+    // ====================================================================================================
+    // CONSTANTS
+    // ====================================================================================================
+
+    /// @dev The minimum quorum percentage that can be set for a group, which is 25% of the group size.
     uint256 private constant QUORUM_MIN_THRESHOLD = 25;
+
+    /// @dev The maximum  quorum percentage that can be set for a group, which is 50% of the group size.
     uint256 private constant QUORUM_MAX_THRESHOLD = 50;
+
+    /// @dev The maximum number of members in a group for which the maximum quorum can be set.
     uint256 private constant GROUP_SIZE_FOR_MAX_QUORUM = 30;
+
+    /// @dev The minimum number of members in a group for which the minimum quorum can be set.
     uint256 private constant GROUP_SIZE_FOR_MIN_QUORUM = 200;
 
 // ====================================================================================================================
@@ -122,7 +262,29 @@ contract VoteManager is Initializable, OwnableUpgradeable, UUPSUpgradeable, IVot
 // ====================================================================================================================
 //                                       EXTERNAL STATE-CHANGING FUNCTIONS
 // ====================================================================================================================
+    /**
+     * @dev This function can only be called by the contract owner (governor).
+     * @custom:error AddressCannotBeZero If the provided verifier address is zero.
+     * @custom:error AddressIsNotAContract If the provided address is not a contract.
+     * @custom:error AddressDoesNotSupportInterface If the provided address does not support the `verifyProof` function.
+     */
+     function setVoteVerifier(address _voteVerifier) external onlyOwner nonZeroAddress(_voteVerifier) {
+        if(_voteVerifier.code.length == 0) revert AddressIsNotAContract();
+        if(!_supportsIVoteInterface(_voteVerifier)) revert AddressDoesNotSupportInterface();
 
+        voteVerifier = IVoteVerifier(_voteVerifier);
+        emit VoteVerifierAddressSet(_voteVerifier);
+    }
+
+    /**
+     * @dev This function can only be called by the contract owner (governor).
+     * @custom:error InvalidMerkleRoot If the provided Merkle root does not match the current root.
+     * @custom:error InvalidContextHash If the provided context key does not match the proof context hash.
+     * @custom:error VoteNullifierAlreadyUsed If the vote nullifier has already been used.
+     * @custom:error RootNotYetInitialized If the current root has not been initialized.
+     * @custom:error InvalidVoteProof If the provided proof is invalid.
+     * @custom:error KeyCannotBeZero If the context or group key are zero.
+     */
     function verifyVote(
         uint256[24] calldata proof,
         uint256[4] calldata publicSignals,
@@ -134,6 +296,7 @@ contract VoteManager is Initializable, OwnableUpgradeable, UUPSUpgradeable, IVot
         external 
         onlyOwner
         nonZeroKey(contextKey) 
+        nonZeroKey(groupKey)
     {
         // save values from public signals:
         bytes32 proofContextHash = bytes32(publicSignals[0]);
@@ -143,7 +306,7 @@ contract VoteManager is Initializable, OwnableUpgradeable, UUPSUpgradeable, IVot
         
         // check root
         if (currentRoot == bytes32(0)) revert RootNotYetInitialized();
-        if (proofRoot != currentRoot) revert InvalidMerkeRoot();
+        if (proofRoot != currentRoot) revert InvalidMerkleRoot();
 
         // check that vote nullifier has not been used
         if (voteNullifiers[contextKey]) revert VoteNullifierAlreadyUsed();
@@ -158,8 +321,11 @@ contract VoteManager is Initializable, OwnableUpgradeable, UUPSUpgradeable, IVot
         // mark the vote nullifier as used
         voteNullifiers[proofVoteNullifier] = true;
 
+        // Emit event for verified vote
+        emit VoteVerified(contextKey, proofVoteNullifier, proofVoteContentHash);
+
         // Update vote tally for proposal
-        VoteTally storage tally = proposalStatuses[contextKey].tally;
+        VoteTally storage tally = proposalResults[contextKey].tally;
 
         if ( choice == VoteChoice.Abstain) {
             tally.abstain++;
@@ -168,30 +334,22 @@ contract VoteManager is Initializable, OwnableUpgradeable, UUPSUpgradeable, IVot
         } else if ( choice == VoteChoice.No) {
             tally.no++;
         }
-        emit VoteVerified(contextKey, proofVoteNullifier, proofVoteContentHash);
-
+        emit VoteTallyUpdated(contextKey, tally.abstain, tally.yes, tally.no);
+        
         // Update the proposal's Passed status
-        updateProposalStatus(contextKey, groupKey);
+        _updateProposalStatus(contextKey, groupKey);
     }
 
-    function updateProposalStatus(
-        bytes32 contextKey, 
-        bytes32 groupKey
-    ) external onlyOwner nonZeroKey(contextKey) nonZeroKey(groupKey) {
-        GroupParams storage params = groupParams[groupKey];
-        ProposalResult storage proposal = proposalResults[contextKey];
-
-        if (params.memberCount == 0 || params.quorum == 0) revert GroupParamsCannotBeZero(); 
-        bool hasPassed = _computePassedStatus(params, proposal);
-
-        // update passed value
-        status.passed = hasPassed;
-    }
-
+    
+    /**
+     * @dev This function can only be called by the contract owner (governor).
+     * @custom:error KeyCannotBeZero If the group key is zero.
+     * @custom:error InvalidMemberCount If the member count is zero or greater than 1024.
+     */
     function setMemberCount(bytes32 groupKey, uint256 _memberCount) external onlyOwner nonZeroKey(groupKey) {
         if (_memberCount == 0 || _memberCount > 1024) revert InvalidMemberCount();
 
-        groupGovernance[groupKey].memberCount = _memberCount;
+        groupParams[groupKey].memberCount = _memberCount;
         emit MemberCountSet(groupKey, _memberCount);
 
         if (_memberCount <= GROUP_SIZE_FOR_MAX_QUORUM ) {
@@ -214,14 +372,45 @@ contract VoteManager is Initializable, OwnableUpgradeable, UUPSUpgradeable, IVot
 // ====================================================================================================================
 //                                       PRIVATE HELPER FUNCTIONS
 // ====================================================================================================================
-
     
+    /**
+     * @dev Computes and updates the proposal's passed status based on the group parameters and proposal results.
+     * @param contextKey The unique identifier for the proposal context.
+     * @param groupKey The unique identifier for the group.
+     * @custom:error KeyCannotBeZero If the context or group key are zero.
+     * @custom:error GroupParamsCannotBeZero If the member count or quorum is zero.
+     */
+    function _updateProposalStatus(bytes32 contextKey, bytes32 groupKey) private nonZeroKey(contextKey) nonZeroKey(groupKey) {
+        GroupParams storage params = groupParams[groupKey];
+        ProposalResult storage proposal = proposalResults[contextKey];
+
+        if (params.memberCount == 0 || params.quorum == 0) revert GroupParamsCannotBeZero(); 
+        bool hasPassed = _computePassedStatus(params, proposal);
+
+        // update passed value
+        proposal.passed = hasPassed;
+        emit ProposalStatusUpdated(contextKey, hasPassed);
+    }
+
+    /**
+     * @dev Sets the quorum for a group.
+     * @param groupKey The unique identifier for the group.
+     * @param _quorum The quorum percentage to set for the group.
+     * @custom:error QuorumCannotBeLowerThan25 If the quorum is less than 25.
+     * @custom:error KeyCannotBeZero If the group key is zero.
+     */
     function _setQuorum(bytes32 groupKey, uint256 _quorum) private nonZeroKey(groupKey) {
         if (_quorum < 25 ) revert QuorumCannotBeLowerThan25();
-        groupGovernance[groupKey].quorum = _quorum;
+        groupParams[groupKey].quorum = _quorum;
         emit QuorumSet(groupKey, _quorum);
     }
     
+    /**
+     * @dev Computes whether a proposal has passed based on the group parameters and proposal results.
+     * @param params The group parameters containing member count and quorum.
+     * @param proposal The proposal result containing the vote tally.
+     * @return bool True if the proposal has passed, false otherwise.
+     */
     function _computePassedStatus(GroupParams memory params, ProposalResult memory proposal) private view returns (bool)  {    
         uint256 totalVotes = proposal.tally.abstain + proposal.tally.yes + proposal.tally.no;
         uint256 requiredVotes = _ceilDiv(params.memberCount * params.quorum, 100);
@@ -233,6 +422,20 @@ contract VoteManager is Initializable, OwnableUpgradeable, UUPSUpgradeable, IVot
         return hasReachedQuorum && hasYesMajority;
     }
 
+    /**
+     * @dev Performs linear interpolation to find the y value for a given x.
+     * @param x The x value for which to find the corresponding y value.
+     * @param x1 The first x value in the range.
+     * @param y1 The corresponding y value for x1.
+     * @param x2 The second x value in the range.
+     * @param y2 The corresponding y value for x2.
+     * @return uint256 The interpolated y value for the given x.
+     * @custom:error InvalidX1X2Inputs If x2 is less than or equal to x1.
+     * @custom:error InvalidY1Y2Inputs If y2 is less than or equal to y1.
+     * @custom:error InvalidXInput If x is less than or equal to x1 or greater than x2.
+     * @notice This function assumes that x1 < x2 and y1 < y2.
+     * It uses the formula: y = y1 + slope * (x - x1), where slope = (y2 - y1) / (x2 - x1).
+     */
     function _linearInterpolation(
         uint256 x,
         uint256 x1,
@@ -250,7 +453,13 @@ contract VoteManager is Initializable, OwnableUpgradeable, UUPSUpgradeable, IVot
         return y1 + slope * (x - x1);
     }
 
-     function _ceilDiv(uint256 a, uint256 b) private pure returns (uint256) {
+    /**
+     * @dev Computes the ceiling division of two numbers.
+     * @param a The numerator.
+     * @param b The denominator.
+     * @return uint256 The result of the ceiling division.
+     */
+    function _ceilDiv(uint256 a, uint256 b) private pure returns (uint256) {
         return (a + b - 1) / b;
     }
 

--- a/hardhat/hardhat.config.js
+++ b/hardhat/hardhat.config.js
@@ -30,8 +30,10 @@ module.exports = {
       "MembershipManager",
       "ProposalManager",
       "GovernanceManager",
+      "VoteManager",
       "ProposalVerifier",
-      "ProposalClaimVerifier"
+      "ProposalClaimVerifier",
+      "VotingVerifier"
     ],
     except: [
       "MockMembershipManagerV2", 


### PR DESCRIPTION
* created a setMemberCount function - it is meant to be called by the relayer via the GM every time a new Merkle root is set for a group either via initRoot or setRoot. The setMemberCount  function updates the group parameters (member count and quorum) within the VM (instead of within the MM) to make the calls more efficient. We should probably set a minimum threshold for the group size (eg., below 3 members no voting is possible).
* The quorum threshold is updated internally whenever the setMemberCount  function is called. The quorum is dynamically calculated as a function of the group size. See Trello for more details. 
* The external view functions are still missing.