### PR TITLE
feat: optimize Merkle tree root calculation to campaign creation phase

### DIFF
--- a/frontend/src/components/GenerateCredentialsOverlay.jsx
+++ b/frontend/src/components/GenerateCredentialsOverlay.jsx
@@ -192,12 +192,12 @@ function GenerateCredentialsOverlay({ group, onClose }) {
         groupId,
         groupMemberId,
         commitment: result.commitment,
-        onSuccess: ({ root, treeVersion, memberCount }) => {
+        onSuccess: ({ memberCount, commitmentId }) => {
           console.log(
-            `Database updated successfully. Root: ${root}, Version: ${treeVersion}, Member Count: ${memberCount}`
+            `Database updated successfully. Member Count: ${memberCount}, Commitment ID: ${commitmentId}`
           );
           toast.success(
-            "Credentials generated successfully! Blockchain will be updated when next campaign is created."
+            "Credentials generated successfully! Root will be calculated and blockchain updated when next campaign is created."
           );
         },
         onError: (error) => {

--- a/frontend/src/hooks/queries/merkleTreeRoots/useAtomicCommitmentInsertion.js
+++ b/frontend/src/hooks/queries/merkleTreeRoots/useAtomicCommitmentInsertion.js
@@ -1,8 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "../../../services/supabase";
-import { MerkleTreeService } from "../../../scripts/merkleTreeService";
-import { insertMerkleTreeRoot } from "../../../services/apiMerkleTreeRoots";
-import { toggleMerkleTreeRootActive } from "../../../services/apiMerkleTreeRoots";
 
 export const useAtomicCommitmentInsertion = () => {
   const queryClient = useQueryClient();
@@ -21,7 +18,7 @@ export const useAtomicCommitmentInsertion = () => {
         console.log("Group Member ID:", groupMemberId);
         console.log("Commitment:", commitment.toString());
 
-        // Step 1: Call RPC function to insert commitment and get all commitments
+        // Step 1: Call RPC function to insert commitment
         const { data: rpcResult, error: rpcError } = await supabase.rpc(
           "atomic_commitment_insertion",
           {
@@ -42,58 +39,16 @@ export const useAtomicCommitmentInsertion = () => {
           throw new Error("Commitment insertion failed");
         }
 
-        // Step 2: Calculate root with the fresh commitments from database
-        console.log("All commitments from RPC:", rpcResult.all_commitments);
-        const allCommitments = rpcResult.all_commitments.map((c) => BigInt(c));
-        console.log("Converted commitments:", allCommitments);
-
-        const { root } = await MerkleTreeService.createMerkleTree(
-          allCommitments
-        );
-        console.log("Calculated root:", root);
-
-        // Step 3: Get tree version from RPC result (already calculated atomically)
-        const treeVersion = rpcResult.tree_version;
-        console.log("Tree version from RPC (atomic):", treeVersion);
-
-        // Step 4: Insert the new Merkle tree root into database FIRST
-        console.log("Inserting root into database...");
-        const newRootRecord = await insertMerkleTreeRoot({
-          groupId,
-          rootHash: root,
-          treeVersion: treeVersion,
-        });
-        console.log("Root inserted into database:", newRootRecord);
-
-        // Step 5: Toggle active status (deactivate old, activate new)
-        console.log("Toggling root active status...");
-        await toggleMerkleTreeRootActive({
-          groupId: groupId,
-          newRootId: newRootRecord.root_id,
-        });
-        console.log("Root active status updated");
-
-        // Note: Blockchain update has been moved to campaign creation
-        // This reduces blockchain transactions by batching root updates
+        console.log("Commitment inserted successfully");
 
         if (onSuccess) {
           onSuccess({
-            root: root,
-            treeVersion: treeVersion,
             memberCount: rpcResult.member_count,
-            rootId: newRootRecord.root_id,
+            commitmentId: rpcResult.commitment_id,
           });
         }
 
-        // Update the current tree version in the cache
-        queryClient.setQueryData(["currentMerkleTreeRootVersion"], treeVersion);
-
-        return {
-          ...rpcResult,
-          calculated_root: root,
-          tree_version: treeVersion,
-          root_id: newRootRecord.root_id,
-        };
+        return rpcResult;
       } catch (error) {
         console.error("Error in atomic commitment insertion:", error);
         if (onError) {

--- a/frontend/src/hooks/queries/merkleTreeRoots/useCalculateAndStoreRoot.js
+++ b/frontend/src/hooks/queries/merkleTreeRoots/useCalculateAndStoreRoot.js
@@ -1,0 +1,130 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { MerkleTreeService } from "../../../scripts/merkleTreeService";
+import { getLeavesByGroupId } from "../../../services/apiMerkleTreeLeaves";
+import { insertMerkleTreeRoot } from "../../../services/apiMerkleTreeRoots";
+import { toggleMerkleTreeRootActive } from "../../../services/apiMerkleTreeRoots";
+import { getActiveMerkleTreeRoot } from "../../../services/apiMerkleTreeRoots";
+
+/**
+ * Custom hook for calculating and storing Merkle tree root during campaign creation
+ * This hook calculates the root from all active commitments and stores it in the database
+ * Only inserts a new root if it differs from the current active root
+ *
+ * @returns {Object} An object containing the mutation function and its state
+ * @property {Function} calculateAndStoreRoot - Function to trigger the root calculation and storage
+ * @property {boolean} isLoading - Whether the mutation is in progress
+ * @property {Error|null} error - Any error that occurred during the mutation
+ */
+export const useCalculateAndStoreRoot = () => {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async ({ groupId, onSuccess, onError }) => {
+      try {
+        console.log("Starting root calculation and storage...");
+        console.log("Group ID:", groupId);
+
+        // Step 1: Get current active root for comparison
+        const existingActiveRoot = await getActiveMerkleTreeRoot({ groupId });
+        console.log("Existing active root:", existingActiveRoot);
+
+        // Step 2: Get all active commitments for the group
+        const activeCommitments = await getLeavesByGroupId({ groupId });
+        console.log("Active commitments count:", activeCommitments.length);
+
+        if (activeCommitments.length === 0) {
+          throw new Error("No active commitments found for this group");
+        }
+
+        // Step 3: Convert commitments to BigInt and calculate new root
+        const allCommitments = activeCommitments.map((c) =>
+          BigInt(c.commitment_value)
+        );
+        console.log("Converted commitments:", allCommitments);
+
+        const { root } = await MerkleTreeService.createMerkleTree(
+          allCommitments
+        );
+        console.log("Calculated new root:", root);
+
+        // Step 4: Compare with existing root
+        if (existingActiveRoot && existingActiveRoot.root_hash === root) {
+          console.log("Root is unchanged, skipping database insertion");
+
+          if (onSuccess) {
+            onSuccess({
+              root: root,
+              treeVersion: existingActiveRoot.tree_version,
+              memberCount: activeCommitments.length,
+              rootId: existingActiveRoot.root_id,
+              rootUnchanged: true,
+            });
+          }
+
+          return {
+            root: root,
+            treeVersion: existingActiveRoot.tree_version,
+            memberCount: activeCommitments.length,
+            rootId: existingActiveRoot.root_id,
+            rootUnchanged: true,
+          };
+        }
+
+        // Step 5: Root is different, proceed with insertion
+        console.log("Root has changed, inserting new root into database...");
+        const treeVersion = existingActiveRoot
+          ? existingActiveRoot.tree_version + 1
+          : 1;
+        console.log("New tree version:", treeVersion);
+
+        const newRootRecord = await insertMerkleTreeRoot({
+          groupId,
+          rootHash: root,
+          treeVersion: treeVersion,
+        });
+        console.log("Root inserted into database:", newRootRecord);
+
+        // Step 6: Toggle active status (deactivate old, activate new)
+        console.log("Toggling root active status...");
+        await toggleMerkleTreeRootActive({
+          groupId: groupId,
+          newRootId: newRootRecord.root_id,
+        });
+        console.log("Root active status updated");
+
+        if (onSuccess) {
+          onSuccess({
+            root: root,
+            treeVersion: treeVersion,
+            memberCount: activeCommitments.length,
+            rootId: newRootRecord.root_id,
+            rootUnchanged: false,
+          });
+        }
+
+        // Update the current tree version in the cache
+        queryClient.setQueryData(["currentMerkleTreeRootVersion"], treeVersion);
+
+        return {
+          root: root,
+          treeVersion: treeVersion,
+          memberCount: activeCommitments.length,
+          rootId: newRootRecord.root_id,
+          rootUnchanged: false,
+        };
+      } catch (error) {
+        console.error("Error in root calculation and storage:", error);
+        if (onError) {
+          onError(error);
+        }
+        throw error;
+      }
+    },
+  });
+
+  return {
+    calculateAndStoreRoot: mutation.mutateAsync,
+    isLoading: mutation.isPending,
+    error: mutation.error,
+  };
+};

--- a/frontend/src/scripts/rpc-functions/atomic_commitment_insertion.txt
+++ b/frontend/src/scripts/rpc-functions/atomic_commitment_insertion.txt
@@ -4,11 +4,7 @@ CREATE OR REPLACE FUNCTION atomic_commitment_insertion(
   p_commitment_value TEXT
 ) RETURNS JSON AS $$
 DECLARE
-  v_all_commitments TEXT[];
   v_new_commitment_record RECORD;
-  v_new_tree_version INTEGER;
-  v_current_root_record RECORD;
-  v_max_tree_version INTEGER;
   v_commitment_count INTEGER;
 BEGIN
   -- Set reasonable timeouts
@@ -16,28 +12,19 @@ BEGIN
   SET statement_timeout = '60s';
   
   BEGIN
-    -- Step 1: Lock and read all active commitments FIRST
-    WITH LOCKED_COMMITMENTS AS (
-      SELECT commitment_value, created_at
-      FROM ignitionzk.merkle_tree_leaves
-      WHERE group_id = p_group_id AND is_active = true
-      FOR UPDATE
-    )
-    SELECT ARRAY_AGG(commitment_value ORDER BY created_at), COUNT(*)
-    INTO v_all_commitments, v_commitment_count
-    FROM LOCKED_COMMITMENTS;
+    -- Step 1: Lock the table and count active commitments (separate operations)
+    SELECT COUNT(*)
+    INTO v_commitment_count
+    FROM ignitionzk.merkle_tree_leaves
+    WHERE group_id = p_group_id AND is_active = true;
     
-    -- Handle case where no commitments exist yet
-    IF v_all_commitments IS NULL THEN
-      v_all_commitments := ARRAY[]::TEXT[];
-      v_commitment_count := 0;
-    END IF;
+    -- Lock the table to prevent concurrent modifications
+    PERFORM 1 FROM ignitionzk.merkle_tree_leaves 
+    WHERE group_id = p_group_id 
+    LIMIT 1 
+    FOR UPDATE;
     
-    -- Step 2: Calculate tree version based on commitment count (after this insertion)
-    -- Tree version = number of commitments after insertion
-    v_new_tree_version := v_commitment_count + 1;
-    
-    -- Step 3: Insert the new commitment
+    -- Step 2: Insert the new commitment
     INSERT INTO ignitionzk.merkle_tree_leaves (
       group_member_id,
       commitment_value,
@@ -52,15 +39,10 @@ BEGIN
       NOW()
     ) RETURNING * INTO v_new_commitment_record;
     
-    -- Step 4: Add the new commitment to the array
-    v_all_commitments := array_append(v_all_commitments, p_commitment_value);
-    
     RETURN json_build_object(
       'success', true,
-      'all_commitments', v_all_commitments,
-      'member_count', array_length(v_all_commitments, 1),
-      'commitment_id', v_new_commitment_record.commitment_id,
-      'tree_version', v_new_tree_version
+      'member_count', v_commitment_count + 1,
+      'commitment_id', v_new_commitment_record.commitment_id
     );
     
   EXCEPTION


### PR DESCRIPTION
- Move root calculation from credential generation to campaign creation
- Simplify atomic_commitment_insertion RPC to only insert commitments
- Add useCalculateAndStoreRoot hook for centralized root calculation
- Update useInsertEpoch to calculate root before blockchain update
- Fix PostgreSQL FOR UPDATE compatibility with aggregate functions
- Update UI feedback to reflect asynchronous root updates

This change improves performance by deferring expensive root calculations until campaign creation, while maintaining data consistency through atomic database operations.

feat: optimize root comparison to skip unnecessary operations

- Add root comparison check in useCalculateAndStoreRoot
- Skip database insertion when calculated root matches existing root
- Skip blockchain updates when root is unchanged in useInsertEpoch
- Add rootUnchanged flag to indicate when root has been modified
- Preserve existing treeVersion and rootId when root is unchanged
- Improve efficiency by avoiding expensive operations when no changes needed

This optimization reduces database writes, blockchain gas costs, and campaign creation time when the Merkle tree root hasn't actually changed.