### PR TITLE
Implemented proposal content check before proposal execution

### DIFF
--- a/foundry/test/MembershipManager.t.sol
+++ b/foundry/test/MembershipManager.t.sol
@@ -4,18 +4,25 @@ pragma solidity ^0.8.28;
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
 
+// OZ Imports:
 import { Clones } from "@openzeppelin/contracts/proxy/Clones.sol";
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+// Contracts:
+import { MembershipManager } from "hardhat-contracts/managers/MembershipManager.sol";
+import { ProposalManager } from "hardhat-contracts/managers/ProposalManager.sol";
+import { ERC721IgnitionZK } from "hardhat-contracts/token/ERC721IgnitionZK.sol";
+
+// Verifiers:
 import { MockProposalVerifier } from "hardhat-contracts/mocks/MockProposalVerifier.sol";
 import { MockProposalClaimVerifier } from "hardhat-contracts/mocks/MockProposalClaimVerifier.sol";
-import { MembershipManager } from "hardhat-contracts/managers/MembershipManager.sol";
-import { IMembershipManager } from "hardhat-contracts/interfaces/IMembershipManager.sol";
-import { ProposalManager } from "hardhat-contracts/managers/ProposalManager.sol";
-import { IProposalManager } from "hardhat-contracts/interfaces/IProposalManager.sol";
-import { IMembershipManager } from "hardhat-contracts/interfaces/IMembershipManager.sol";
-import { IProposalVerifier } from "hardhat-contracts/interfaces/IProposalVerifier.sol";
-import { ERC721IgnitionZK } from "hardhat-contracts/token/ERC721IgnitionZK.sol";
 import { MembershipVerifier } from "hardhat-contracts/verifiers/MembershipVerifier.sol";
+
+// Interfaces: 
+import { IMembershipManager } from "hardhat-contracts/interfaces/managers/IMembershipManager.sol";
+import { IProposalManager } from "hardhat-contracts/interfaces/managers/IProposalManager.sol";
+import { IMembershipManager } from "hardhat-contracts/interfaces/managers/IMembershipManager.sol";
+import { IProposalVerifier } from "hardhat-contracts/interfaces/verifiers/IProposalVerifier.sol";
 
 
 contract MembershipManagerTest is Test {

--- a/foundry/test/ProposalManager.t.sol
+++ b/foundry/test/ProposalManager.t.sol
@@ -4,17 +4,26 @@ pragma solidity ^0.8.28;
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
 
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+// OZ Imports:
+import { Clones } from "@openzeppelin/contracts/proxy/Clones.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+// Contracts:
+import { MembershipManager } from "hardhat-contracts/managers/MembershipManager.sol";
+import { ProposalManager } from "hardhat-contracts/managers/ProposalManager.sol";
+import { ERC721IgnitionZK } from "hardhat-contracts/token/ERC721IgnitionZK.sol";
+
+// Verifiers:
 import { MockProposalVerifier } from "hardhat-contracts/mocks/MockProposalVerifier.sol";
 import { MockProposalClaimVerifier } from "hardhat-contracts/mocks/MockProposalClaimVerifier.sol";
-import { MembershipManager } from "hardhat-contracts/managers/MembershipManager.sol";
-import { IMembershipManager } from "hardhat-contracts/interfaces/IMembershipManager.sol";
-import { ProposalManager } from "hardhat-contracts/managers/ProposalManager.sol";
-import { IProposalManager } from "hardhat-contracts/interfaces/IProposalManager.sol";
-import { IMembershipManager } from "hardhat-contracts/interfaces/IMembershipManager.sol";
-import { IProposalVerifier } from "hardhat-contracts/interfaces/IProposalVerifier.sol";
-import { ERC721IgnitionZK } from "hardhat-contracts/token/ERC721IgnitionZK.sol";
 import { MembershipVerifier } from "hardhat-contracts/verifiers/MembershipVerifier.sol";
+
+// Interfaces: 
+import { IMembershipManager } from "hardhat-contracts/interfaces/managers/IMembershipManager.sol";
+import { IProposalManager } from "hardhat-contracts/interfaces/managers/IProposalManager.sol";
+import { IMembershipManager } from "hardhat-contracts/interfaces/managers/IMembershipManager.sol";
+import { IProposalVerifier } from "hardhat-contracts/interfaces/verifiers/IProposalVerifier.sol";
 
 contract Dummy {
     function dummyFunction() external pure returns (string memory) {

--- a/hardhat/contracts/libraries/VoteTypes.sol
+++ b/hardhat/contracts/libraries/VoteTypes.sol
@@ -19,11 +19,13 @@ library VoteTypes {
         uint256 quorum;
     }
 
-    /// @dev The proposal status struct, which contains the vote tally and a boolean indicating if the proposal has passed.
+    /// @dev The proposal status struct, which contains the vote tally, a boolean indicating if the proposal has passed and the submission nullifier.
     /// Passed status is determined by the quorum and majority of votes.
+    /// The submission nullifier is used to check proposal content validity when executing proposals.
     struct ProposalResult {
         VoteTally tally;
         bool passed;
+        bytes32 submissionNullifier; 
     }
 
     /// @dev The QuorumParams struct, which contains the minimum and maximum quorum thresholds and group size parameters.

--- a/hardhat/contracts/managers/VoteManager.sol
+++ b/hardhat/contracts/managers/VoteManager.sol
@@ -59,6 +59,9 @@ contract VoteManager is Initializable, OwnableUpgradeable, UUPSUpgradeable, IVot
     /// @notice Thrown if the tallying of votes is inconsistent, e.g., total votes exceed member count.
     error TallyingInconsistent();
 
+    /// @notice Thrown if the submission nullifier does not match the expected value.
+    error SubmissionNullifierMismatch();
+
     // ====================================================================================================
     // GROUP PARAM ERRORS (memberCount, Quorum)
     // ====================================================================================================
@@ -326,7 +329,7 @@ contract VoteManager is Initializable, OwnableUpgradeable, UUPSUpgradeable, IVot
         bytes32 proofVoteNullifier = bytes32(publicSignals[1]);
         uint256 proofVoteChoiceHash = publicSignals[2];
         bytes32 proofRoot = bytes32(publicSignals[3]);
-        //bytes32 proofSubmissionNullifier = bytes32(publicSignals[4]);
+        bytes32 proofSubmissionNullifier = bytes32(publicSignals[4]);
 
         // check root
         if (currentRoot == bytes32(0)) revert RootNotYetInitialized();
@@ -365,33 +368,31 @@ contract VoteManager is Initializable, OwnableUpgradeable, UUPSUpgradeable, IVot
         }
 
         // Update vote tally for proposal
-        //VoteTypes.ProposalResult storage result = proposalResults[contextKey];
-        VoteTypes.VoteTally storage tally = proposalResults[contextKey].tally;
+        VoteTypes.ProposalResult storage result = proposalResults[contextKey];
+        //VoteTypes.VoteTally storage tally = proposalResults[contextKey].tally;
 
         if ( inferredChoice == VoteTypes.VoteChoice.No) {
-            tally.no++;
+            result.tally.no++;
         } else if ( inferredChoice == VoteTypes.VoteChoice.Yes) {
-            tally.yes++;
+            result.tally.yes++;
         } else if ( inferredChoice == VoteTypes.VoteChoice.Abstain) {
-            tally.abstain++;
+            result.tally.abstain++;
         }
         emit VoteTallyUpdated(contextKey, [
-            tally.no, 
-            tally.yes, 
-            tally.abstain
+            result.tally.no, 
+            result.tally.yes, 
+            result.tally.abstain
             ]);
         
         // Update the proposal's Passed status
         _updateProposalStatus(contextKey, groupKey);
 
         // register the proposal submission nullifier in the proposal record
-        /*
         if (result.submissionNullifier == bytes32(0)) {
             result.submissionNullifier = proofSubmissionNullifier;
         } else {
             if (result.submissionNullifier != proofSubmissionNullifier) revert SubmissionNullifierMismatch();
         }
-        */
     }
 
     

--- a/hardhat/test/ProposalManager.test.js
+++ b/hardhat/test/ProposalManager.test.js
@@ -42,7 +42,7 @@ describe("Proposal Manager Unit Tests:", function () {
         const deployedFixtures = await deployFixtures();
 
         ({
-            membershipManager, proposalManager, voteManager, governanceManager, 
+            membershipManager, proposalManager, voteManager, governanceManager, nftImplementation,
             membershipVerifier, proposalVerifier, proposalClaimVerifier, voteVerifier,
             mockMembershipVerifier, mockProposalVerifier, mockProposalClaimVerifier, mockVoteVerifier
         } = deployedFixtures);


### PR DESCRIPTION
* Implemented proposal content check: GM checks expected submission nullifier matches the stored submission nullifier in the VM before calling distributeGrant
* Adjusted the ProposalResult struct to include the submission nullifier
* The submission nullifier is stored in the proposalResults mapping when the first vote is verified. In subsequent votes the function just checks that the stored nullifier matches the one in the current public signals.
* Ensured existing unit tests run successfully after some adjustments